### PR TITLE
Use netstandard2.0 in order to be used in .net 4.6.1

### DIFF
--- a/src/sfdx4csharp.csproj
+++ b/src/sfdx4csharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>sfdx4csharp</PackageId>
     <PackageVersion>0.0.1</PackageVersion>
     <Authors>Marc-Antoine Veilleux</Authors>
@@ -17,7 +17,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix: Can generate for netstandard2.0 in order to be used in .net 4.6.1
https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-platforms-support