### PR TITLE
Uses TargetFrameworks instead of netstandard.

### DIFF
--- a/src/sfdx4csharp.csproj
+++ b/src/sfdx4csharp.csproj
@@ -17,9 +17,9 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <PackageId>sfdx4csharp</PackageId>
-    <PackageVersion>0.0.2</PackageVersion>
+    <PackageVersion>0.0.3</PackageVersion>
     <Authors>Marc-Antoine Veilleux</Authors>
     <Owners>SMarc-Antoine Veilleux</Owners>
     <Title>SFDX for C#</Title>
@@ -33,7 +33,7 @@ limitations under the License.
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I introduce the uses of netstandard in 0.0.2. This was a mistake, we should focus on different target instead in order to not have to load netstandard in a net461 project.